### PR TITLE
fix: module not found

### DIFF
--- a/mcp-client-python/client.py
+++ b/mcp-client-python/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from typing import Optional
 from contextlib import AsyncExitStack
 
@@ -8,6 +7,7 @@ from mcp.client.stdio import stdio_client
 
 from anthropic import Anthropic
 from dotenv import load_dotenv
+from pathlib import Path
 
 load_dotenv()  # load environment variables from .env
 
@@ -31,10 +31,10 @@ class MCPClient:
             raise ValueError("Server script must be a .py or .js file")
 
         if is_python:
-            directory, file_name = os.path.split(server_script_path)
+            path = Path(server_script_path).resolve()
             server_params = StdioServerParameters(
                 command="uv",
-                args=["--directory", directory, "run", file_name],
+                args=["--directory", path.parent, "run", path.name],
                 env=None,
             )
         else:


### PR DESCRIPTION
## Motivation and Context
Solved #25. Earlier when the user did a command like `uv run client.py "C:\Users\Robin Roy\Desktop\quickstart-resources\weather-server-python\weather.py"` it'll throw `ModuleNotFoundError` because the spawned process was unable to use the `.venv` libs. I modified `uv` to use the libs.

## How Has This Been Tested?
I tested it locally for the problems #23 and #24.

## Breaking Changes
None.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally (no tests)
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
