### PR TITLE
Remove unused variable `toolResults`

### DIFF
--- a/mcp-client-typescript/index.ts
+++ b/mcp-client-typescript/index.ts
@@ -100,7 +100,6 @@ class MCPClient {
 
     // Process response and handle tool calls
     const finalText = [];
-    const toolResults = [];
 
     for (const content of response.content) {
       if (content.type === "text") {
@@ -114,7 +113,6 @@ class MCPClient {
           name: toolName,
           arguments: toolArgs,
         });
-        toolResults.push(result);
         finalText.push(
           `[Calling tool ${toolName} with args ${JSON.stringify(toolArgs)}]`,
         );


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Similar to this commit dfc92478e2b7087dfb369ad36695e8b9ff459f3f, the `toolResults` variable is also unused in the typescript client.

## Motivation and Context
Providing a cleaner example.

## How Has This Been Tested?
It was run locally

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
