### PR TITLE
fix: rename input_schema to inputSchema to match expected key

### DIFF
--- a/mcp-client-typescript/index.ts
+++ b/mcp-client-typescript/index.ts
@@ -63,12 +63,12 @@ class MCPClient {
         return {
           name: tool.name,
           description: tool.description,
-          input_schema: tool.inputSchema,
+          inputSchema: tool.inputSchema,
         };
       });
       console.log(
         "Connected to server with tools:",
-        this.tools.map(({ name }) => name),
+        this.tools.map(({ name }) => name)
       );
     } catch (e) {
       console.log("Failed to connect to MCP server: ", e);
@@ -116,7 +116,7 @@ class MCPClient {
         });
         toolResults.push(result);
         finalText.push(
-          `[Calling tool ${toolName} with args ${JSON.stringify(toolArgs)}]`,
+          `[Calling tool ${toolName} with args ${JSON.stringify(toolArgs)}]`
         );
 
         // Continue conversation with tool results
@@ -133,7 +133,7 @@ class MCPClient {
         });
 
         finalText.push(
-          response.content[0].type === "text" ? response.content[0].text : "",
+          response.content[0].type === "text" ? response.content[0].text : ""
         );
       }
     }


### PR DESCRIPTION
### Provide a brief summary of your changes

Fix typo in key name from `input_schema` to `inputSchema` in `mcp-client-typescript/index.ts` to match the expected key.

### Motivation and Context

The original key name `input_schema` caused issues because the system expects `inputSchema`. This change aligns the code with the correct naming convention and prevents potential runtime errors.

### How Has This Been Tested?

Tested locally by running the affected code and confirmed it works without errors.

### Breaking Changes

None. This is a non-breaking typo fix.

### Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

### Checklist

* [x] I have read the repository’s contribution guidelines
* [x] My code follows the project’s style guidelines
* [x] My changes do not break existing tests
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

### Additional context

No additional context.

