### PR TITLE
fix: update deprecated Anthropic model

### DIFF
--- a/mcp-client-python/client.py
+++ b/mcp-client-python/client.py
@@ -64,7 +64,7 @@ class MCPClient:
 
         # Initial Claude API call
         response = self.anthropic.messages.create(
-            model="claude-3-5-sonnet-20241022",
+            model="claude-3-7-sonnet-latest",
             max_tokens=1000,
             messages=messages,
             tools=available_tools
@@ -97,7 +97,7 @@ class MCPClient:
 
                 # Get next response from Claude
                 response = self.anthropic.messages.create(
-                    model="claude-3-5-sonnet-20241022",
+                    model="claude-3-7-sonnet-latest",
                     max_tokens=1000,
                     messages=messages,
                 )

--- a/mcp-client-python/client.py
+++ b/mcp-client-python/client.py
@@ -64,7 +64,7 @@ class MCPClient:
 
         # Initial Claude API call
         response = self.anthropic.messages.create(
-            model="claude-3-7-sonnet-latest",
+            model="claude-sonnet-4-0",
             max_tokens=1000,
             messages=messages,
             tools=available_tools
@@ -97,7 +97,7 @@ class MCPClient:
 
                 # Get next response from Claude
                 response = self.anthropic.messages.create(
-                    model="claude-3-7-sonnet-latest",
+                    model="claude-sonnet-4-0",
                     max_tokens=1000,
                     messages=messages,
                 )

--- a/mcp-client-typescript/index.ts
+++ b/mcp-client-typescript/index.ts
@@ -92,7 +92,7 @@ class MCPClient {
 
     // Initial Claude API call
     const response = await this.anthropic.messages.create({
-      model: "claude-3-7-sonnet-latest",
+      model: "claude-sonnet-4-0",
       max_tokens: 1000,
       messages,
       tools: this.tools,
@@ -127,7 +127,7 @@ class MCPClient {
 
         // Get next response from Claude
         const response = await this.anthropic.messages.create({
-          model: "claude-3-7-sonnet-latest",
+          model: "claude-sonnet-4-0",
           max_tokens: 1000,
           messages,
         });

--- a/mcp-client-typescript/index.ts
+++ b/mcp-client-typescript/index.ts
@@ -92,7 +92,7 @@ class MCPClient {
 
     // Initial Claude API call
     const response = await this.anthropic.messages.create({
-      model: "claude-3-5-sonnet-20241022",
+      model: "claude-3-7-sonnet-latest",
       max_tokens: 1000,
       messages,
       tools: this.tools,
@@ -127,7 +127,7 @@ class MCPClient {
 
         // Get next response from Claude
         const response = await this.anthropic.messages.create({
-          model: "claude-3-5-sonnet-20241022",
+          model: "claude-3-7-sonnet-latest",
           max_tokens: 1000,
           messages,
         });


### PR DESCRIPTION
Fix broken official MCP quickstart tutorial by replacing deprecated Anthropic model `claude-3-5-sonnet-20241022` with `claude-3-7-sonnet-latest`.

## Motivation and Context  
The [official MCP quickstart tutorial](https://modelcontextprotocol.io/quickstart/client#node) is currently broken. It references a **deprecated Anthropic model**, which causes new users following the docs to hit a 404 error from the Anthropic API instead of a working example. This update restores the tutorial’s end-to-end functionality.

## How Has This Been Tested?  
- Cloned the quickstart repo.  
- Built and ran the **TypeScript client** exactly as shown in the tutorial.  
- Executed a sample query; confirmed no errors and a valid tool call.  

## Breaking Changes  
- None. This is a non-breaking change affecting only the example code.

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Checklist  
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)  
- [x] My code follows the repository's style guidelines  
- [x] New and existing tests pass locally  
- [x] I have updated the example documentation as needed  

## Additional context  
Without this fix, users encounter:
```
NotFoundError: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-3-5-sonnet-20241022"}}
```
This patch ensures that new users who copy code from the tutorial get a working client immediately.
