### PR TITLE
Weather server missing main function

### DIFF
--- a/weather-server-python/weather.py
+++ b/weather-server-python/weather.py
@@ -89,6 +89,9 @@ Forecast: {period['detailedForecast']}
 
     return "\n---\n".join(forecasts)
 
-if __name__ == "__main__":
+def main():
     # Initialize and run the server
-    mcp.run(transport='stdio')
+    mcp.run(transport='stdio')    
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The weather server script does not run.

```
❯ uv run weather
Traceback (most recent call last):
  File "/projects/quickstart-resources/weather-server-python/.venv/bin/weather", line 4, in <module>
    from weather import main
ImportError: cannot import name 'main' from 'weather' (/projects/quickstart-resources/weather-server-python/weather.py)
```

The script definition in `pyproject.toml` is looking for a `main` function which does not exist.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
