### PR TITLE
Fix the "module not found" error

### DIFF
--- a/mcp-client-python/client.py
+++ b/mcp-client-python/client.py
@@ -7,6 +7,7 @@ from mcp.client.stdio import stdio_client
 
 from anthropic import Anthropic
 from dotenv import load_dotenv
+from pathlib import Path
 
 load_dotenv()  # load environment variables from .env
 
@@ -30,14 +31,19 @@ class MCPClient:
         is_js = server_script_path.endswith('.js')
         if not (is_python or is_js):
             raise ValueError("Server script must be a .py or .js file")
-            
-        command = "python" if is_python else "node"
-        server_params = StdioServerParameters(
-            command=command,
-            args=[server_script_path],
-            env=None
-        )
-        
+
+        if is_python:
+            path = Path(server_script_path).resolve()
+            server_params = StdioServerParameters(
+                command="uv",
+                args=["--directory", str(path.parent), "run", path.name],
+                env=None,
+            )
+        else:
+            server_params = StdioServerParameters(
+                command="node", args=[server_script_path], env=None
+            )
+
         stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
         self.stdio, self.write = stdio_transport
         self.session = await self.exit_stack.enter_async_context(ClientSession(self.stdio, self.write))


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

Finishing another PR from @robinroy03 as they are [no longer working on fixing the original one](https://github.com/modelcontextprotocol/quickstart-resources/pull/26#issuecomment-3536443607).

Solved https://github.com/modelcontextprotocol/quickstart-resources/issues/25. Earlier when the user did a command like uv run client.py "C:\Users\Robin Roy\Desktop\quickstart-resources\weather-server-python\weather.py" it'll throw ModuleNotFoundError because the spawned process was unable to use the .venv libs. 

## How Has This Been Tested?
Locally.

## Breaking Changes
No.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
N/A