### PR TITLE
Add mcp-safety-scanner CI

### DIFF
--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -1,0 +1,23 @@
+name: MCP Safety Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: TheodorNEngoy/mcp-safety-scanner@v0
+        with:
+          path: .
+          fail-on: high
+          format: github
+


### PR DESCRIPTION
Adds a lightweight MCP/tool-server safety scan in CI using TheodorNEngoy/mcp-safety-scanner@v0 (JS/TS/Python/Go heuristics).\n\n- Runs on PRs + pushes to main\n- Fails only on high+ severity\n- Emits GitHub annotations for findings