### PR TITLE
Docs: add security notes for network-exposed MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 A repository of servers and clients from the following Model Context Protocol tutorials:
 - [Quickstart](https://modelcontextprotocol.io/quickstart) – a simple MCP weather server
 - [Building MCP clients](https://modelcontextprotocol.io/tutorials/building-a-client) – an LLM-powered chatbot MCP client
+
+## Security Note
+
+These examples are intentionally minimal. If you expose an MCP server over a network (HTTP/SSE/WebSocket), add authentication and basic hardening (CORS allowlist, request size limits, timeouts, rate limits, and log redaction). See [`SECURITY.md`](./SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Notes (Quickstart Resources)
+
+These examples are intentionally minimal and optimized for learning. Before using similar patterns in production, apply basic hardening.
+
+## If You Expose An MCP Server Over A Network (HTTP/SSE/WebSocket)
+
+- **Require authentication**: do not expose unauthenticated tool endpoints to the public internet.
+- **Treat browsers as hostile**:
+  - Do not use wildcard CORS (`Access-Control-Allow-Origin: *`) on authenticated endpoints.
+  - Do not reflect `Origin` without allowlist validation.
+  - Prefer an explicit origin allowlist.
+- **Bound resource usage**:
+  - Set an explicit maximum request body size.
+  - Add timeouts to outbound requests.
+  - Add rate limits (per user/token and/or per IP).
+- **Avoid RCE primitives in tools**:
+  - Avoid `eval` / dynamic code execution.
+  - Avoid invoking a shell with attacker-controlled input (`exec`, `sh -c`, `shell=True`).
+  - If you must run commands, enforce strict allowlists and pass arguments as arrays (no shell).
+- **Don't leak secrets**: redact `Authorization`, cookies, and API keys from logs.
+
+## Local-Only Usage
+
+If you run these examples locally via stdio transports, your main risks are still:
+
+- accidentally adding dangerous tools (filesystem/shell) without strict controls
+- leaking secrets via logs or environment
+
+When in doubt: keep tool capability narrow and add input validation.
+


### PR DESCRIPTION
These quickstart examples are intentionally minimal and often run locally via stdio.

This PR adds a short security note in the root README plus a `SECURITY.md` checklist for anyone who adapts these examples into a network-exposed MCP server (HTTP/SSE/WebSocket): auth, CORS allowlist, request size limits, timeouts, rate limits, log redaction, and avoiding obvious RCE primitives.

No CI/workflow changes; docs only.
