### PR TITLE
Add client-level connect handshake to stdio transport

### DIFF
--- a/mcp-client-ruby/Gemfile
+++ b/mcp-client-ruby/Gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 gem "anthropic"
 gem "base64"
 gem "dotenv"
-gem "mcp", '>= 0.9.1'
+gem "mcp", '>= 0.15.0'

--- a/mcp-client-ruby/client.rb
+++ b/mcp-client-ruby/client.rb
@@ -28,6 +28,7 @@ class MCPClient
 
     @transport = MCP::Client::Stdio.new(command: command, args: [server_script_path])
     @mcp_client = MCP::Client.new(transport: @transport)
+    @mcp_client.connect
 
     tool_names = @mcp_client.tools.map(&:name)
     puts "\nConnected to server with tools: #{tool_names}"


### PR DESCRIPTION
## Motivation and Context

Follow-up to https://github.com/modelcontextprotocol/ruby-sdk/pull/336

mcp gem 0.15.0 introduced an explicit `MCP::Client#connect` method for the stdio transport, aligning with the Python and TypeScript SDKs which require explicit handshake calls regardless of transport type:

- Python SDK: `ClientSession.initialize()` https://github.com/modelcontextprotocol/python-sdk
- TypeScript SDK: `Client.connect(transport)` https://github.com/modelcontextprotocol/typescript-sdk

This sample is updated to call `@mcp_client.connect` explicitly after creating the client, demonstrating the recommended initialization pattern. The Gemfile constraint is bumped to `>= 0.15.0` to require the new API.

## How Has This Been Tested?

Ran the sample against `weather-server-ruby` and confirmed the connection, tool listing, and chat loop continue to work as expected.

## Breaking Changes

None. The change updates the sample to use the new explicit `connect` API, which was added as a non-breaking addition in mcp gem 0.15.0.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
