### PR TITLE
Fix issue 28 with tool use and improve the logic overall

### DIFF
--- a/mcp-client-python/client.py
+++ b/mcp-client-python/client.py
@@ -12,6 +12,7 @@ load_dotenv()  # load environment variables from .env
 
 # Claude model constant
 ANTHROPIC_MODEL = "claude-sonnet-4-5"
+MAX_TOOL_TURNS = 10
 
 
 class MCPClient:
@@ -64,45 +65,52 @@ class MCPClient:
         """Process a query using Claude and available tools"""
         messages = [{"role": "user", "content": query}]
 
-        response = await self.session.list_tools()
+        tools_response = await self.session.list_tools()
         available_tools = [
             {"name": tool.name, "description": tool.description, "input_schema": tool.inputSchema}
-            for tool in response.tools
+            for tool in tools_response.tools
         ]
 
-        # Initial Claude API call
+        final_text = []
+
         response = self.anthropic.messages.create(
             model=ANTHROPIC_MODEL, max_tokens=1000, messages=messages, tools=available_tools
         )
 
-        # Process response and handle tool calls
-        final_text = []
+        for _ in range(MAX_TOOL_TURNS):
+            tool_uses = []
+            for content in response.content:
+                if content.type == "text":
+                    final_text.append(content.text)
+                elif content.type == "tool_use":
+                    tool_uses.append(content)
 
-        for content in response.content:
-            if content.type == "text":
-                final_text.append(content.text)
-            elif content.type == "tool_use":
-                tool_name = content.name
-                tool_args = content.input
+            if not tool_uses:
+                return "\n".join(final_text)
 
-                # Execute tool call
-                result = await self.session.call_tool(tool_name, tool_args)
-                final_text.append(f"[Calling tool {tool_name} with args {tool_args}]")
-
-                # Continue conversation with tool results
-                if hasattr(content, "text") and content.text:
-                    messages.append({"role": "assistant", "content": content.text})
-                messages.append({"role": "user", "content": result.content})
-
-                # Get next response from Claude
-                response = self.anthropic.messages.create(
-                    model=ANTHROPIC_MODEL,
-                    max_tokens=1000,
-                    messages=messages,
+            tool_results = []
+            for tool_use in tool_uses:
+                result = await self.session.call_tool(tool_use.name, tool_use.input)
+                final_text.append(f"[Calling tool {tool_use.name} with args {tool_use.input}]")
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use.id,
+                        "content": result.content,
+                    }
                 )
 
-                final_text.append(response.content[0].text)
+            messages.append({"role": "assistant", "content": response.content})
+            messages.append({"role": "user", "content": tool_results})
 
+            response = self.anthropic.messages.create(
+                model=ANTHROPIC_MODEL,
+                max_tokens=1000,
+                messages=messages,
+                tools=available_tools,
+            )
+
+        final_text.append(f"[Stopped after {MAX_TOOL_TURNS} tool-use turns]")
         return "\n".join(final_text)
 
     async def chat_loop(self):

--- a/mcp-client-python/client.py
+++ b/mcp-client-python/client.py
@@ -121,13 +121,15 @@ class MCPClient:
         while True:
             try:
                 query = input("\nQuery: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                break
 
-                if query.lower() == "quit":
-                    break
+            if query.lower() == "quit":
+                break
 
+            try:
                 response = await self.process_query(query)
                 print("\n" + response)
-
             except Exception as e:
                 print(f"\nError: {str(e)}")
 


### PR DESCRIPTION
## Motivation and Context

  - Fix `process_query` in `mcp-client-python/client.py` so tool-use turns conform to the Anthropic Messages API: append the assistant's full content (preserving the `tool_use` block) and reply with a proper `tool_result` block carrying `tool_use_id`, replacing the previous plain-user-message workaround and the dead `hasattr(content, "text")` check that the API spec confirms can never be true.
  - Restructure the response handler into a turn-level loop so the client correctly handles parallel tool calls in a single response (executing all `tool_use` blocks and returning all matching `tool_result` blocks in one user message) and chained tool calls across turns (passing `tools` on every follow-up request so the model can keep using them).
  - Add `MAX_TOOL_TURNS = 10` cap to prevent unbounded tool-use loops; on cap-hit the client appends a `[Stopped after N tool-use turns]` notice and returns the accumulated output.
  - Fix `chat_loop` to exit cleanly on `EOFError` / `KeyboardInterrupt` instead of being swallowed by a broad `except Exception` and respinning forever. This also makes the python client smoke test pass reliably under non-tty stdin regardless of whether `ANTHROPIC_API_KEY` is set (previously the test hung whenever the key was loaded from `.env`).
 
## How Has This Been Tested?
  - [x] `tests/smoke-test.sh` passes locally (all 5 tests green, no hangs) both with and without `ANTHROPIC_API_KEY` set.
  - [x] Manual: run `client.py` against `weather-server-python` with a real `ANTHROPIC_API_KEY` and ask a query that triggers a single tool call (e.g. "What's
  the weather in NYC?") — verify the model receives the tool result and produces a final answer.
  - [x] Manual: ask a query that triggers multiple sequential tool calls (e.g. "Compare the weather in NYC and SF") — verify all calls execute and the final answer references both results.
  - [x] Manual: verify the `MAX_TOOL_TURNS` cap path by lowering the constant locally and confirming the `[Stopped after N tool-use turns]` notice appears.
  - [x] Manual: press Ctrl+D or Ctrl+C at the `Query:` prompt — verify the client exits cleanly instead of spinning.

## Breaking Changes
N/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
 Fixes issue #28.
