### PR TITLE
Fix tool use in TypeScript client, mirroring #141

### DIFF
--- a/mcp-client-typescript/index.ts
+++ b/mcp-client-typescript/index.ts
@@ -1,7 +1,10 @@
 import { Anthropic } from "@anthropic-ai/sdk";
 import {
+  ContentBlockParam,
   MessageParam,
   Tool,
+  ToolResultBlockParam,
+  ToolUseBlock,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -13,6 +16,7 @@ import dotenv from "dotenv";
 dotenv.config(); // load environment variables from .env
 
 const ANTHROPIC_MODEL = "claude-sonnet-4-5";
+const MAX_TOOL_TURNS = 10;
 
 class MCPClient {
   private mcp: Client;
@@ -89,52 +93,62 @@ class MCPClient {
       },
     ];
 
-    // Initial Claude API call
-    const response = await this.anthropic.messages.create({
+    let response = await this.anthropic.messages.create({
       model: ANTHROPIC_MODEL,
       max_tokens: 1000,
       messages,
       tools: this.tools,
     });
 
-    // Process response and handle tool calls
-    const finalText = [];
+    const finalText: string[] = [];
 
-    for (const content of response.content) {
-      if (content.type === "text") {
-        finalText.push(content.text);
-      } else if (content.type === "tool_use") {
-        // Execute tool call
-        const toolName = content.name;
-        const toolArgs = content.input as { [x: string]: unknown } | undefined;
+    for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
+      const toolUses: ToolUseBlock[] = [];
 
+      for (const block of response.content) {
+        if (block.type === "text") {
+          finalText.push(block.text);
+        } else if (block.type === "tool_use") {
+          toolUses.push(block);
+        }
+      }
+
+      if (toolUses.length === 0) {
+        return finalText.join("\n");
+      }
+
+      const toolResults: ToolResultBlockParam[] = [];
+      for (const toolUse of toolUses) {
+        const toolArgs = toolUse.input as { [x: string]: unknown } | undefined;
+        finalText.push(
+          `[Calling tool ${toolUse.name} with args ${JSON.stringify(toolArgs)}]`,
+        );
         const result = await this.mcp.callTool({
-          name: toolName,
+          name: toolUse.name,
           arguments: toolArgs,
         });
-        finalText.push(
-          `[Calling tool ${toolName} with args ${JSON.stringify(toolArgs)}]`,
-        );
-
-        // Continue conversation with tool results
-        messages.push({
-          role: "user",
-          content: result.content as string,
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: toolUse.id,
+          content: result.content as ToolResultBlockParam["content"],
         });
-
-        // Get next response from Claude
-        const response = await this.anthropic.messages.create({
-          model: ANTHROPIC_MODEL,
-          max_tokens: 1000,
-          messages,
-        });
-
-        finalText.push(
-          response.content[0].type === "text" ? response.content[0].text : "",
-        );
       }
+
+      messages.push({
+        role: "assistant",
+        content: response.content as unknown as ContentBlockParam[],
+      });
+      messages.push({ role: "user", content: toolResults });
+
+      response = await this.anthropic.messages.create({
+        model: ANTHROPIC_MODEL,
+        max_tokens: 1000,
+        messages,
+        tools: this.tools,
+      });
     }
 
+    finalText.push(`[Stopped after ${MAX_TOOL_TURNS} tool-use turns]`);
     return finalText.join("\n");
   }
 
@@ -146,20 +160,38 @@ class MCPClient {
       input: process.stdin,
       output: process.stdout,
     });
+    // rl.question() doesn't reject on stdin EOF on its own; wire its close
+    // event to an AbortSignal so EOF (Ctrl-D) and SIGINT both unblock it.
+    const ac = new AbortController();
+    const onClose = () => ac.abort();
+    rl.on("close", onClose);
+    const onSigint = () => rl.close();
+    process.once("SIGINT", onSigint);
 
     try {
       console.log("\nMCP Client Started!");
       console.log("Type your queries or 'quit' to exit.");
 
       while (true) {
-        const message = await rl.question("\nQuery: ");
-        if (message.toLowerCase() === "quit") {
+        let message: string;
+        try {
+          message = await rl.question("\nQuery: ", { signal: ac.signal });
+        } catch {
           break;
         }
-        const response = await this.processQuery(message);
-        console.log("\n" + response);
+
+        if (message.toLowerCase() === "quit") break;
+
+        try {
+          const response = await this.processQuery(message);
+          console.log("\n" + response);
+        } catch (e) {
+          console.log(`\nError: ${e instanceof Error ? e.message : String(e)}`);
+        }
       }
     } finally {
+      process.off("SIGINT", onSigint);
+      rl.off("close", onClose);
       rl.close();
     }
   }


### PR DESCRIPTION
## Motivation and Context

PR #141 fixed the Anthropic Messages API tool-use handling in the **Python** client (`mcp-client-python/client.py`). The **TypeScript** client (`mcp-client-typescript/index.ts`) carried the same bugs, but they stayed latent because the smoke test's mock MCP server returns an empty tool list, so the tool-use branch never executes.

The original TS `processQuery` is not spec-compliant: it sends each tool result back as a plain-text `user` message (no `tool_result` block, no `tool_use_id`), never appends the assistant turn carrying the `tool_use` block, drops `tools` from follow-up calls, and has no loop for chained tool calls.

The observable symptom is **not** a hard API error — the Messages API tolerates the malformed shape (it accepts the result as plain user text). Instead the bug shows up as **silently incorrect answers and broken tool chaining**. Verified against the real Messages API on the pristine `main` build with a query that needs two sequential tool calls ("Compare the weather in NYC and San Francisco"): the model called `get-forecast` for NYC, then — because `tools` was dropped on the follow-up — could not call it again for SF, so **SF was never fetched** and the model **fabricated** the San Francisco half of the comparison. Separately, `chatLoop` crashes with `ERR_USE_AFTER_CLOSE` on stdin EOF (Ctrl-D) / SIGINT (Ctrl-C).

This PR mirrors #141 for TypeScript:

- Reply to each `tool_use` with a proper `tool_result` block carrying `tool_use_id`, and append the assistant's full content (preserving the `tool_use` block) instead of sending the result as a plain user string.
- Restructure `processQuery` into a turn-level loop so parallel tool calls in a single response **and** chained tool calls across turns both work; pass `tools` on every follow-up request so the model can keep using them.
- Add a `MAX_TOOL_TURNS = 10` cap with a `[Stopped after N tool-use turns]` notice to prevent unbounded tool-use loops.
- Fix `chatLoop` to exit cleanly on EOF (Ctrl-D) and SIGINT (Ctrl-C). Node's `readline/promises` `question()` does not reject on stdin EOF on its own (it just hangs / then throws `ERR_USE_AFTER_CLOSE`), so an `AbortController` wired to the readline `close` event unblocks it.

## How Has This Been Tested?

Tested side-by-side against a pristine `main` build to confirm the fix changes real behavior:

- [x] `tests/smoke-test.sh` passes locally (5/5 green).
- [x] Structural verification via a fake `/v1/messages` endpoint that records requests: confirmed the follow-up call sends `[user, assistant(tool_use), user(tool_result)]` with `tool_use_id`, keeps the `tools` array, and makes a third call when the model chains another `tool_use`.
- [x] Manual, **real `ANTHROPIC_API_KEY`** against `weather-server-typescript`:
  - Single tool call ("What's the weather in NYC?") — model receives the tool result and produces a final answer.
  - Chained tool calls ("Compare the weather in NYC and San Francisco.") — **both** `get-forecast` calls execute and the final answer is built from real fetched data for both cities. On the pristine `main` build the same query fetched NYC only and fabricated SF.
- [x] `MAX_TOOL_TURNS` cap path verified by lowering the constant locally and confirming the `[Stopped after N tool-use turns]` notice appears.
- [x] EOF (Ctrl-D) at the `Query:` prompt exits cleanly (exit 0) instead of crashing with `ERR_USE_AFTER_CLOSE` as `main` does.

## Breaking Changes

N/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling

## Additional context

Mirrors #141 (which fixed the same issue, originally #28, for the Python client).

🦉 Implementation and verification assisted by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
