### PR TITLE
Update Ruby MCP client example

### DIFF
--- a/mcp-client-ruby/Gemfile
+++ b/mcp-client-ruby/Gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "anthropic"
-gem "base64"
+gem "anthropic", '>= 1.60.0'
 gem "dotenv"
 gem "mcp", '>= 0.15.0'


### PR DESCRIPTION
Follow-up to #121.

This PR removes the `base64` dependency from the Gemfile, as it became a runtime dependency of Claude SDK for Ruby v1.60.0+.
https://github.com/anthropics/anthropic-sdk-ruby/pull/161#issuecomment-5221400980

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
