### PR TITLE
Cover the Ruby examples in the smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
         with:
           go-version: "1.25"
 
-      # 3.4 is the oldest series still supported; 3.2 reached end of life in
-      # March 2026.
+      # 3.4 is the current stable series. 3.3 is supported until March 2027; 3.2
+      # reached end of life in March 2026.
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,12 @@ jobs:
         with:
           go-version: "1.25"
 
+      # 3.4 is the oldest series still supported; 3.2 reached end of life in
+      # March 2026.
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+
       - name: Run smoke tests
         run: ./tests/smoke-test.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,9 +7,11 @@ This directory contains smoke tests for the MCP quickstart examples. These tests
 The smoke tests verify:
 
 - **Servers**: Each weather server (Python, TypeScript, Rust, Go) can start, respond to MCP protocol requests, and honour the output schemas it advertises
-- **Clients**: The Python and TypeScript MCP clients can connect to a mock server and list tools
+- **Clients**: The Python, TypeScript and Ruby MCP clients can connect to a mock server and list tools
 
-The Go and Rust clients are not covered here: on `main` both abort when no `.env` file is present, so they cannot be driven without credentials. Making them start credential-free is a change in their own directories, so their coverage lands with those changes rather than here. The Ruby examples are not covered either — the `mcp` gem cannot negotiate protocol revision `2026-07-28`.
+The Go and Rust clients are not covered here: on `main` both abort when no `.env` file is present, so they cannot be driven without credentials. Making them start credential-free is a change in their own directories, so their coverage lands with those changes rather than here.
+
+The Ruby **weather server** is not covered, for an upstream reason rather than a local one. The `mcp` gem negotiates `2026-07-28`, but its server never emits the `resultType` field that revision makes mandatory, so the test client rejects its responses — including `tools/list`. That is a fix for the gem, not something an example can work around. The Ruby **client** is covered: there it is the gem's client code that runs, and the server it is pointed at is the mock.
 
 ## Structured content
 
@@ -37,6 +39,8 @@ Tool calls reach the live NWS API. When it is unreachable the tools return an er
 - **Rust** stable
 - **Cargo** (for Rust builds)
 - **Go** 1.25+
+- **Ruby** 3.4+ (3.2 and 3.3 satisfy the gems, but 3.2 is past end of life)
+- **Bundler** (ships with Ruby 3.x)
 
 ## How It Works
 
@@ -111,6 +115,9 @@ nvm install 24
 
 # Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Ruby (via rbenv)
+rbenv install 3.4
 ```
 
 ## Adding New Tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,12 +6,10 @@ This directory contains smoke tests for the MCP quickstart examples. These tests
 
 The smoke tests verify:
 
-- **Servers**: Each weather server (Python, TypeScript, Rust, Go) can start, respond to MCP protocol requests, and honour the output schemas it advertises
+- **Servers**: Each weather server (Python, TypeScript, Rust, Go, Ruby) can start, respond to MCP protocol requests, and honour the output schemas it advertises
 - **Clients**: The Python, TypeScript and Ruby MCP clients can connect to a mock server and list tools
 
 The Go and Rust clients are not covered here: on `main` both abort when no `.env` file is present, so they cannot be driven without credentials. Making them start credential-free is a change in their own directories, so their coverage lands with those changes rather than here.
-
-The Ruby **weather server** is not covered, for an upstream reason rather than a local one. The `mcp` gem negotiates `2026-07-28`, but its server never emits the `resultType` field that revision makes mandatory, so the test client rejects its responses — including `tools/list`. That is a fix for the gem, not something an example can work around. The Ruby **client** is covered: there it is the gem's client code that runs, and the server it is pointed at is the mock.
 
 ## Structured content
 

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -88,6 +88,15 @@ test_weather_server_go() {
 # and exits. Empty rather than unset: dotenv skips a name already present in
 # ENV, so a key in the environment or a local .env would start the chat loop.
 
+# Test: Ruby weather server
+test_weather_server_ruby() {
+    check_dependency ruby || return 1
+    check_dependency bundle || return 1
+    local server_dir="${PROJECT_ROOT}/weather-server-ruby"
+    ensure_bundled "${server_dir}" || return 1
+    (cd "${server_dir}" && node "${TEST_CLIENT}" bundle exec ruby weather.rb)
+}
+
 # Test: Python MCP client
 test_mcp_client_python() {
     check_dependency uv || return 1
@@ -119,14 +128,13 @@ test_mcp_client_ruby() {
 # is present, so they cannot be driven without credentials. Making them start
 # credential-free is a change in their own directories, so their coverage lands
 # with those changes rather than here.
-#
-# Nor is the Ruby weather server: the mcp gem does not stamp the resultType
-# field that 2026-07-28 requires, so the test client rejects its responses.
+
 print_header "Running smoke tests"
 run_test "weather-server-python" test_weather_server_python
 run_test "weather-server-typescript" test_weather_server_typescript
 run_test "weather-server-rust" test_weather_server_rust
 run_test "weather-server-go" test_weather_server_go
+run_test "weather-server-ruby" test_weather_server_ruby
 run_test "mcp-client-python" test_mcp_client_python
 run_test "mcp-client-typescript" test_mcp_client_typescript
 run_test "mcp-client-ruby" test_mcp_client_ruby

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -100,12 +100,24 @@ test_mcp_client_typescript() {
     node "${client_dir}/build/index.js" "${MOCK_SERVER}" >/dev/null 2>&1
 }
 
+# Test: Ruby MCP client
+test_mcp_client_ruby() {
+    check_dependency ruby || return 1
+    check_dependency bundle || return 1
+    local client_dir="${PROJECT_ROOT}/mcp-client-ruby"
+    ensure_bundled "${client_dir}" || return 1
+    (cd "${client_dir}" && bundle exec ruby client.rb "${MOCK_SERVER}") >/dev/null 2>&1
+}
+
 # Run all tests
 #
-# All four servers are covered. The Go and Rust clients are not: on main both
-# abort when no .env file is present, so they cannot be driven without
-# credentials. Making them start credential-free is a change in their own
-# directories, so their coverage lands with those changes rather than here.
+# The Go and Rust clients are not covered: on main both abort when no .env file
+# is present, so they cannot be driven without credentials. Making them start
+# credential-free is a change in their own directories, so their coverage lands
+# with those changes rather than here.
+#
+# Nor is the Ruby weather server: the mcp gem does not stamp the resultType
+# field that 2026-07-28 requires, so the test client rejects its responses.
 print_header "Running smoke tests"
 run_test "weather-server-python" test_weather_server_python
 run_test "weather-server-typescript" test_weather_server_typescript
@@ -113,6 +125,7 @@ run_test "weather-server-rust" test_weather_server_rust
 run_test "weather-server-go" test_weather_server_go
 run_test "mcp-client-python" test_mcp_client_python
 run_test "mcp-client-typescript" test_mcp_client_typescript
+run_test "mcp-client-ruby" test_mcp_client_ruby
 
 # Print summary
 echo ""

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -84,10 +84,6 @@ test_weather_server_go() {
     node "${TEST_CLIENT}" "${server_bin}"
 }
 
-# The client tests drive the no-API-key path, where each client prints a notice
-# and exits. Empty rather than unset: dotenv skips a name already present in
-# ENV, so a key in the environment or a local .env would start the chat loop.
-
 # Test: Ruby weather server
 test_weather_server_ruby() {
     check_dependency ruby || return 1
@@ -96,6 +92,10 @@ test_weather_server_ruby() {
     ensure_bundled "${server_dir}" || return 1
     (cd "${server_dir}" && node "${TEST_CLIENT}" bundle exec ruby weather.rb)
 }
+
+# The client tests drive the no-API-key path, where each client prints a notice
+# and exits. Empty rather than unset: dotenv skips a name already present in
+# ENV, so a key in the environment or a local .env would start the chat loop.
 
 # Test: Python MCP client
 test_mcp_client_python() {

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -84,11 +84,15 @@ test_weather_server_go() {
     node "${TEST_CLIENT}" "${server_bin}"
 }
 
+# The client tests drive the no-API-key path, where each client prints a notice
+# and exits. Empty rather than unset: dotenv skips a name already present in
+# ENV, so a key in the environment or a local .env would start the chat loop.
+
 # Test: Python MCP client
 test_mcp_client_python() {
     check_dependency uv || return 1
     local client_dir="${PROJECT_ROOT}/mcp-client-python"
-    uv --directory "${client_dir}" run python "${client_dir}/client.py" "${MOCK_SERVER}" >/dev/null 2>&1
+    ANTHROPIC_API_KEY= uv --directory "${client_dir}" run python "${client_dir}/client.py" "${MOCK_SERVER}" >/dev/null 2>&1
 }
 
 # Test: TypeScript MCP client
@@ -97,7 +101,7 @@ test_mcp_client_typescript() {
     check_dependency npm || return 1
     local client_dir="${PROJECT_ROOT}/mcp-client-typescript"
     ensure_built "${client_dir}" || return 1
-    node "${client_dir}/build/index.js" "${MOCK_SERVER}" >/dev/null 2>&1
+    ANTHROPIC_API_KEY= node "${client_dir}/build/index.js" "${MOCK_SERVER}" >/dev/null 2>&1
 }
 
 # Test: Ruby MCP client
@@ -106,7 +110,7 @@ test_mcp_client_ruby() {
     check_dependency bundle || return 1
     local client_dir="${PROJECT_ROOT}/mcp-client-ruby"
     ensure_bundled "${client_dir}" || return 1
-    (cd "${client_dir}" && bundle exec ruby client.rb "${MOCK_SERVER}") >/dev/null 2>&1
+    (cd "${client_dir}" && ANTHROPIC_API_KEY= bundle exec ruby client.rb "${MOCK_SERVER}") >/dev/null 2>&1
 }
 
 # Run all tests

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -138,3 +138,16 @@ ensure_built() {
         run_build "go build in ${dir}" go build -o "server$(exe_suffix)" . || return 1
     fi
 }
+
+# Ensure a Ruby project directory has its gems installed.
+#
+# Unlike ensure_built there is no artefact to test for -- a Ruby example has no
+# build step and Gemfile.lock is gitignored -- so ask Bundler directly.
+ensure_bundled() {
+    local dir=$1
+    cd "${dir}" || return 1
+
+    if ! bundle check >/dev/null 2>&1; then
+        run_build "bundle install in ${dir}" bundle install || return 1
+    fi
+}


### PR DESCRIPTION
CI installed no Ruby toolchain and the suite ran no Ruby example, so nothing under `mcp-client-ruby` or `weather-server-ruby` was exercised by a green build — including #177, which changes the client's Gemfile.

Adds `ruby/setup-ruby` and tests for both Ruby examples. The client connects before it checks `ANTHROPIC_API_KEY` and exits 0 without one, so it runs credential-free like the Python and TypeScript clients.

The Ruby weather server was previously excluded: the `mcp` gem negotiated `2026-07-28` but never emitted the `resultType` field that revision makes mandatory, so the test client rejected its responses. The gem stamps it as of [1.2.0](https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v1.2.0) (2026-08-15). `Gemfile.lock` is gitignored, so a fresh `bundle install` resolves the existing `>= 1.1.0` to 1.2.0 and no manifest change is needed here. Observed against the built test client: on 1.1.0 the run fails with `Invalid result for tools/list: missing required resultType`; on 1.2.0 it connects and lists both tools.

Also pins `ANTHROPIC_API_KEY` empty for all three client tests. They drive the path where no key is set, but did not isolate the variable, so an exported key or a local `.env` sent the client into its interactive chat loop instead. Empty rather than unset, because dotenv skips a name already present in `ENV`.

Verified in a fork with #177 cherry-picked on top: 8/8 pass. On Ruby 3.4 `base64` is no longer a default gem, so that run doubles as confirmation of #177 — without the transitive dependency the client would fail to load.

The Go and Rust clients stay uncovered: both abort when no `.env` file is present, so they cannot be driven without credentials. That is a change in their own directories.