### PR TITLE
Link the dated spec revision, not /draft

### DIFF
--- a/mcp-client-python/README.md
+++ b/mcp-client-python/README.md
@@ -6,6 +6,6 @@ See the [Build an MCP client](https://modelcontextprotocol.io/docs/develop/build
 
 `call_tool` validates every result against the tool's declared output schema, so the spec's client-side SHOULD needs no code here.
 
-The two channels go to different readers: `content` is forwarded to the model, while `structured_content` is used as data — when a tool returns an array, the client counts its items rather than re-reading the prose. See [Structured Content](https://modelcontextprotocol.io/specification/draft/server/tools#structured-content).
+The two channels go to different readers: `content` is forwarded to the model, while `structured_content` is used as data — when a tool returns an array, the client counts its items rather than re-reading the prose. See [Structured Content](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#structured-content).
 
 `Client(transport, mode="auto")` probes `server/discover` and falls back to the `2025-11-25` handshake; `client.protocol_version` reports which era you got. See [Protocol versions](https://py.sdk.modelcontextprotocol.io/v2/protocol-versions/).

--- a/weather-server-python/README.md
+++ b/weather-server-python/README.md
@@ -4,7 +4,7 @@ See the [Build an MCP server](https://modelcontextprotocol.io/docs/develop/build
 
 ## Structured content
 
-Both tools declare an output schema and return `structured_content`. `get_forecast` returns an object; `get_alerts` returns a top-level JSON array, which protocol revision `2026-07-28` is the first to allow — see [Structured Content](https://modelcontextprotocol.io/specification/draft/server/tools#structured-content) in the spec.
+Both tools declare an output schema and return `structured_content`. `get_forecast` returns an object; `get_alerts` returns a top-level JSON array, which protocol revision `2026-07-28` is the first to allow — see [Structured Content](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#structured-content) in the spec.
 
 `Alerts` is a `RootModel[list[Alert]]` rather than a plain `list[Alert]` because the SDK wraps non-object return types as `{"result": ...}`; a `RootModel` is taken as the schema exactly as written. See [Structured Output](https://py.sdk.modelcontextprotocol.io/v2/servers/structured-output/) in the SDK docs.
 


### PR DESCRIPTION
Both READMEs say `2026-07-28` is the first revision to allow an array-rooted schema, then link to `/specification/draft/...`. Draft moves on to the next revision, so the link stops matching the sentence around it.

- `weather-server-python/README.md:7`
- `mcp-client-python/README.md:9`

Came in with #164. The same fix is on the open Go (#166), Rust (#167), and Ruby (#184) branches, so this clears the last of it from `main`.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)