### PR TITLE
Correct README claims that do not match the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Each example lives in its own directory with its own README covering prerequisit
 | Rust       | [`weather-server-rust`](./weather-server-rust)             | [`mcp-client-rust`](./mcp-client-rust)             |
 | Ruby       | [`weather-server-ruby`](./weather-server-ruby)             | [`mcp-client-ruby`](./mcp-client-ruby)             |
 
-All servers communicate over stdio and expose the same two tools: `get_forecast` and `get_alerts` (or `get-forecast` and `get-alerts` in TypeScript). 
+All servers communicate over stdio and expose the same two tools: `get_forecast` and `get_alerts` (or `get-forecast` and `get-alerts` in TypeScript).
 
-All clients accept a path to a server to launch, list its tools, and start an interactive chat loop in which Claude can call those tools. 
+All clients launch a server, list its tools, and start an interactive chat loop in which Claude can call those tools. The Python, TypeScript, and Ruby clients take a path to a server script; the Go and Rust clients take the command to run, plus any arguments.
 
 Note: These example clients need an `ANTHROPIC_API_KEY` to operate. Without a key, each client still connects and lists the server's tools before exiting, so you can verify the MCP wiring without credentials.
 
@@ -34,7 +34,7 @@ Each example only needs its own language toolchain. To work across the whole rep
 - **Node.js** 24+ and **npm**
 - **Python** 3.10+ and **uv**
 - **Go** 1.25+
-- **Rust** stable and **Cargo**
+- **Rust** 1.88+ and **Cargo**
 - **Ruby** 3.4+ and **Bundler**
 
 ## Running the tests
@@ -58,8 +58,7 @@ Contributions are welcome. To submit a change:
 A few conventions to follow, in line with the broader [Model Context Protocol contributing guidelines](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/CONTRIBUTING.md):
 
 - **Keep documentation clear, concise, and technically accurate.** Include code examples where appropriate, and test the commands and links you add.
-- **Disclose AI assistance.** If you used any kind of AI assistance to prepare your contribution, say so in the pull request.
-- **Keep commit messages about the change**, not the tooling used to make it.
+- **Disclose AI assistance.** If you used any kind of AI assistance to prepare your contribution, say so in the pull request or issue. See [AI_POLICY.md](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/AI_POLICY.md) for what the disclosure should cover.
 - **Be respectful.** This project follows the MCP community's [Code of Conduct](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/CODE_OF_CONDUCT.md). Concerns can be reported to mcp-coc@anthropic.com.
 
 ## Security note
@@ -68,4 +67,4 @@ These examples are intentionally minimal. If you expose an MCP server over a net
 
 ## License
 
-This repository is licensed under the [MIT License](./LICENSE).
+The MCP project is transitioning from the MIT License to Apache-2.0. New code contributions are licensed under Apache-2.0, and documentation (excluding specifications) under CC-BY-4.0. Earlier contributions whose authors have not consented to relicensing remain under the MIT License. See [`LICENSE`](./LICENSE) for the full terms.

--- a/mcp-client-ruby/README.md
+++ b/mcp-client-ruby/README.md
@@ -6,7 +6,7 @@ This example accompanies the [Build an MCP client](https://modelcontextprotocol.
 
 ## Prerequisites
 
-- Ruby 3.4+ (3.3 also satisfies the gems)
+- Ruby 3.4+
 - Bundler
 - An [Anthropic API key](https://console.anthropic.com/) (optional — see below)
 

--- a/mcp-client-rust/README.md
+++ b/mcp-client-rust/README.md
@@ -6,7 +6,7 @@ This example accompanies the [Build an MCP client](https://modelcontextprotocol.
 
 ## Prerequisites
 
-- Rust (stable) and Cargo
+- Rust 1.88+ and Cargo
 - An [Anthropic API key](https://console.anthropic.com/) (optional — see below)
 
 ## Setup

--- a/weather-server-ruby/README.md
+++ b/weather-server-ruby/README.md
@@ -9,7 +9,7 @@ This example accompanies the [Build an MCP server](https://modelcontextprotocol.
 
 ## Prerequisites
 
-- Ruby 3.4+ (3.3 also satisfies the gems)
+- Ruby 3.4+
 - Bundler
 
 ## Setup and run

--- a/weather-server-rust/README.md
+++ b/weather-server-rust/README.md
@@ -9,7 +9,7 @@ This example accompanies the [Build an MCP server](https://modelcontextprotocol.
 
 ## Prerequisites
 
-- Rust (stable) and Cargo
+- Rust 1.88+ and Cargo
 
 ## Build and run
 


### PR DESCRIPTION
## Motivation and Context

Follow-up to #188. That PR was a real improvement, and most of its claims check out. Five statements do not match the repository, so this corrects them.

**License (the substantive one).** The new License section said the repository is licensed under the MIT License. `LICENSE` is a transition file: new code contributions are Apache-2.0, documentation excluding specifications is CC-BY-4.0, and only earlier contributions whose authors have not consented to relicensing remain MIT. Replaced with a summary of the actual terms.

**Rust floor.** "Rust (stable)" understates it. `rmcp`, `rmcp-macros`, `darling` and `time` declare `rust-version` 1.88, and `cargo metadata` resolves both `weather-server-rust` and `mcp-client-rust` to 1.88. Someone on an older stable toolchain gets a build failure with no hint from the README. Now "Rust 1.88+".

**Ruby floor.** The aside "(3.3 also satisfies the gems)" is not accurate: `anthropic` requires `>= 3.2.0` and `mcp` requires `>= 2.7.0`, so the gem floor is 3.2. Ruby 3.2 reached EOL on 2026-03-31, so it is not a version to point people at. CI runs 3.4, so the READMEs now just say 3.4+.

**Client invocation.** The root README says "All clients accept a path to a server to launch". The Go and Rust clients take a command plus arguments (`exec.CommandContext(serverArgs[0], serverArgs[1:]...)`, and the Rust usage string is `<server_script_or_binary> [args...]`). The per-client READMEs get this right; only the summary line overreached.

**Contributing conventions.** The bullet "Keep commit messages about the change, not the tooling used to make it" is presented as being in line with the MCP contributing guidelines, which do not mention commit messages. Removed rather than left attributed to a source that does not say it. Added the `AI_POLICY.md` link that `CONTRIBUTING.md` points to, since that is where the disclosure expectations actually live.

Also trimmed trailing whitespace on two lines.

Everything else in #188 was verified and left alone, including the no-API-key behavior (true in all five clients), the `cp .env.example .env` instructions (present in exactly the four client directories that have the file), the hyphen/underscore split in the TypeScript tool names, and the Node/Python/Go floors.

## How Has This Been Tested?

Documentation only, no code changed. Claims were checked against the repository: `cargo metadata` for the Rust MSRV, the rubygems API for `required_ruby_version`, `endoflife.date` for the Ruby EOL dates, `.github/workflows/ci.yml` for the CI versions, and the upstream `CONTRIBUTING.md`, `AI_POLICY.md` and `CODE_OF_CONDUCT.md` for the Contributing section.

## Breaking Changes

No.

## Types of changes

- [x] Documentation update

## Additional context

Not addressed here: `tests/smoke-test.sh` still comments that the Go and Rust clients abort without a `.env` file and skips them. Both now exit cleanly without a key, so that comment is stale and the two clients could join the smoke coverage. That is a change to the tests rather than the docs, so it belongs in its own PR.

AI disclosure: written with Claude Code, which made the edits and ran the verification described above. I reviewed the result.